### PR TITLE
adding support lib to plugin.xml

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -42,6 +42,7 @@
             <color name="csZbarScannerTextBackground">#88000000</color>
             <color name="csZbarScannerBackground">#000000</color>
         </config-file>
+        <framework src="com.android.support:support-v4:23.1.0" />
         <resource-file src="android/res/layout/cszbarscanner.xml" target="res/layout/cszbarscanner.xml" />
         <source-file src="android/ZBarcodeFormat.java" target-dir="src/org/cloudsky/cordovaPlugins" />
         <source-file src="android/ZBar.java" target-dir="src/org/cloudsky/cordovaPlugins" />


### PR DESCRIPTION
It is necessary to add the support-lib to the plugin.xml, or else the build fails if the lib is not included from elsewhere.
